### PR TITLE
Adiciona métodos customizados

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.0.11] - 2025-11-19
+
+* Add setPromoterCustomThankYouScreen method
+* Add setSurveyTheme method
+
 ## [0.0.10] - 2024-07-17
 
 * Update build.gradle required for Flutter v3.22.2

--- a/android/src/main/kotlin/com/inmoment/wootricsdk_flutter/WootricsdkFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/inmoment/wootricsdk_flutter/WootricsdkFlutterPlugin.kt
@@ -108,6 +108,19 @@ class WootricsdkFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
       val disclaimerLinkText: String? = call.argument("disclaimerLinkText")
       val disclaimerLinkURI = Uri.parse(disclaimerLink)
       wootric?.showDisclaimer(disclaimerText, disclaimerLinkURI, disclaimerLinkText)
+    } else if (call.method.equals("setPromoterThankYouMessage")){
+      val message: String? = call.argument("promoterThankYouMessage")
+      val customThankYou = WootricCustomThankYou()
+      customThankYou?.setPromoterText(message)
+      wootric?.setCustomThankYou(customThankYou);
+    } else if (call.methos.equals("setPromoterThankYouLinkWithText")){
+      val label: String? = call.argument("promoterThankYouLinkText")
+      var link: String? = call.argument("promoterThankYouLinkURL")
+      val url = Uri.parse(link)
+      val customThankYou = WootricCustomThankYou()
+      customThankYou?.setPromoterLinkText(label)
+      customThankYou?.setPromoterLinkUri(url)
+      wootric?.setCustomThankYou(customThankYou);
     } else {
       result.notImplemented()
     }

--- a/android/src/main/kotlin/com/inmoment/wootricsdk_flutter/WootricsdkFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/inmoment/wootricsdk_flutter/WootricsdkFlutterPlugin.kt
@@ -113,7 +113,7 @@ class WootricsdkFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
       val customThankYou = WootricCustomThankYou()
       customThankYou?.setPromoterText(message)
       wootric?.setCustomThankYou(customThankYou);
-    } else if (call.methos.equals("setPromoterThankYouLinkWithText")){
+    } else if (call.method.equals("setPromoterThankYouLinkWithText")){
       val label: String? = call.argument("promoterThankYouLinkText")
       var link: String? = call.argument("promoterThankYouLinkURL")
       val url = Uri.parse(link)

--- a/android/src/main/kotlin/com/inmoment/wootricsdk_flutter/WootricsdkFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/inmoment/wootricsdk_flutter/WootricsdkFlutterPlugin.kt
@@ -25,6 +25,9 @@ class WootricsdkFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
   private lateinit var context: Activity
   private var wootric: Wootric? = null
 
+  ///Custom
+  private val customThankYou = WootricCustomThankYou()
+
   override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
     channel = MethodChannel(flutterPluginBinding.binaryMessenger, "wootricsdk_flutter")
     channel.setMethodCallHandler(this)
@@ -108,19 +111,29 @@ class WootricsdkFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
       val disclaimerLinkText: String? = call.argument("disclaimerLinkText")
       val disclaimerLinkURI = Uri.parse(disclaimerLink)
       wootric?.showDisclaimer(disclaimerText, disclaimerLinkURI, disclaimerLinkText)
+    /// CUSTOM
     } else if (call.method.equals("setPromoterThankYouMessage")){
       val message: String? = call.argument("promoterThankYouMessage")
-      val customThankYou = WootricCustomThankYou()
-      customThankYou?.setPromoterText(message)
-      wootric?.setCustomThankYou(customThankYou);
-    } else if (call.method.equals("setPromoterThankYouLinkWithText")){
+      customThankYou.setPromoterText(message)
+      wootric?.setCustomThankYou(customThankYou)
+    /// CUSTOM
+    } else if (call.method.equals("setPromoterThankYouLinkWithText")) {
       val label: String? = call.argument("promoterThankYouLinkText")
       var link: String? = call.argument("promoterThankYouLinkURL")
       val url = Uri.parse(link)
-      val customThankYou = WootricCustomThankYou()
-      customThankYou?.setPromoterLinkText(label)
-      customThankYou?.setPromoterLinkUri(url)
-      wootric?.setCustomThankYou(customThankYou);
+      customThankYou.setPromoterLinkText(label)
+      customThankYou.setPromoterLinkUri(url)
+      wootric?.setCustomThankYou(customThankYou)
+    /// CUSTOM
+    } else if (call.method.equals("setSurveyColors")) {
+      val hexPrimary: String? = call.argument("primary")
+      var hexSecondary: String? = call.argument("secondary")
+      val primaryColor: Int = Color.parseColor(hexPrimary)
+      val secondaryColor: Int = Color.parseColor(hexSecondary)
+      wootric?.setScoreColor(secondaryColor)
+      wootric?.setSurveyColor(primaryColor)
+      wootric?.setThankYouButtonBackgroundColor(primaryColor)
+      wootric?.setSocialSharingColor(primaryColor)
     } else {
       result.notImplemented()
     }

--- a/ios/Classes/SwiftWootricsdkFlutterPlugin.swift
+++ b/ios/Classes/SwiftWootricsdkFlutterPlugin.swift
@@ -161,7 +161,7 @@ public class SwiftWootricsdkFlutterPlugin: NSObject, FlutterPlugin {
             case "setPromoterThankYouMessage":
                 if let arguments = call.arguments as? [String: Any] {
                     let message = arguments["promoterThankYouMessage"] as? String
-                    Wootric.setPromoterThankYouMessage(languageCode)
+                    Wootric.setPromoterThankYouMessage(message)
                 }
            
             case "setPromoterThankYouLinkWithText":
@@ -169,7 +169,7 @@ public class SwiftWootricsdkFlutterPlugin: NSObject, FlutterPlugin {
                     let label = arguments["promoterThankYouLinkText"] as? String
                     let link = arguments["promoterThankYouLinkURL"] as? String
                     let url = URL(string: link!)
-                    Wootric.setPromoterThankYouLinkWithText(label,url)
+                    Wootric.setPromoterThankYouLinkWithText(label, url: url)
            }
 
             default:

--- a/ios/Classes/SwiftWootricsdkFlutterPlugin.swift
+++ b/ios/Classes/SwiftWootricsdkFlutterPlugin.swift
@@ -158,6 +158,20 @@ public class SwiftWootricsdkFlutterPlugin: NSObject, FlutterPlugin {
                     }
                 }
 
+            case "setPromoterThankYouMessage":
+                if let arguments = call.arguments as? [String: Any] {
+                    let message = arguments["promoterThankYouMessage"] as? String
+                    Wootric.setPromoterThankYouMessage(languageCode)
+                }
+           
+            case "setPromoterThankYouLinkWithText":
+                if let arguments = call.arguments as? [String: Any] {
+                    let label = arguments["promoterThankYouLinkText"] as? String
+                    let link = arguments["promoterThankYouLinkURL"] as? String
+                    let url = URL(string: link!)
+                    Wootric.setPromoterThankYouLinkWithText(label,url)
+           }
+
             default:
                 result(FlutterMethodNotImplemented)
             }

--- a/ios/Classes/SwiftWootricsdkFlutterPlugin.swift
+++ b/ios/Classes/SwiftWootricsdkFlutterPlugin.swift
@@ -158,19 +158,33 @@ public class SwiftWootricsdkFlutterPlugin: NSObject, FlutterPlugin {
                     }
                 }
 
+            ///Custom
             case "setPromoterThankYouMessage":
                 if let arguments = call.arguments as? [String: Any] {
                     let message = arguments["promoterThankYouMessage"] as? String
                     Wootric.setPromoterThankYouMessage(message)
                 }
-           
+            ///Custom
             case "setPromoterThankYouLinkWithText":
                 if let arguments = call.arguments as? [String: Any] {
                     let label = arguments["promoterThankYouLinkText"] as? String
                     let link = arguments["promoterThankYouLinkURL"] as? String
                     let url = URL(string: link!)
                     Wootric.setPromoterThankYouLinkWithText(label, url: url)
-           }
+                }
+            ///Custom
+            case "setSurveyColors":
+               if let arguments = call.arguments as? [String: Any] {
+                   let hexPrimaryColor = arguments["primary"] as? String
+                   let hexSecondaryColor = arguments["secondary"] as? String
+                   let primaryColor = convertHEXtoUIColor(hexPrimaryColor!)
+                   let secondaryColor = convertHEXtoUIColor(hexSecondaryColor!)
+                   Wootric.setSliderColor(secondaryColor)
+                   Wootric.setSendButtonBackgroundColor(primaryColor)
+                   Wootric.setThankYouButtonBackgroundColor(primaryColor)
+                   Wootric.setSocialSharing(primaryColor)
+               }
+           
 
             default:
                 result(FlutterMethodNotImplemented)

--- a/lib/wootricsdk_flutter.dart
+++ b/lib/wootricsdk_flutter.dart
@@ -148,6 +148,7 @@ class WootricsdkFlutter {
     WootricsdkFlutterPlatform.instance.showSurveyWithEvent(eventName);
   }
 
+  ///CUSTOM
   /// For promoters (score 9-10)
   /// Display a custom thank you message (setPromoterThankYouMessage)
   /// Display a custom thank you button and link redirect (setPromoterThankYouLinkWithText)
@@ -157,6 +158,7 @@ class WootricsdkFlutter {
         .setPromoterCustomThankYouScreen(message, label, url);
   }
 
+  ///CUSTOM
   ///Override survey theme with custom colors for primary and secondary colors.
   ///To set a custom color pass appropriate [primary] and [secondary] in hex format.
   static setSurveyTheme(String primary, {String? secondary}) {

--- a/lib/wootricsdk_flutter.dart
+++ b/lib/wootricsdk_flutter.dart
@@ -151,7 +151,15 @@ class WootricsdkFlutter {
   /// For promoters (score 9-10)
   /// Display a custom thank you message (setPromoterThankYouMessage)
   /// Display a custom thank you button and link redirect (setPromoterThankYouLinkWithText)
-  static setPromoterCustomThankYouScreen(String message, String label, String url) {
-    WootricsdkFlutterPlatform.instance.setPromoterCustomThankYouScreen(message, label, url);
+  static setPromoterCustomThankYouScreen(
+      String message, String label, String url) {
+    WootricsdkFlutterPlatform.instance
+        .setPromoterCustomThankYouScreen(message, label, url);
+  }
+
+  ///Override survey theme with custom colors for primary and secondary colors.
+  ///To set a custom color pass appropriate [primary] and [secondary] in hex format.
+  static setSurveyTheme(String primary, {String? secondary}) {
+    WootricsdkFlutterPlatform.instance.setSurveyColors(primary, secondary);
   }
 }

--- a/lib/wootricsdk_flutter.dart
+++ b/lib/wootricsdk_flutter.dart
@@ -147,4 +147,11 @@ class WootricsdkFlutter {
   static showSurveyWithEvent(String eventName) {
     WootricsdkFlutterPlatform.instance.showSurveyWithEvent(eventName);
   }
+
+  /// For promoters (score 9-10)
+  /// Display a custom thank you message (setPromoterThankYouMessage)
+  /// Display a custom thank you button and link redirect (setPromoterThankYouLinkWithText)
+  static setPromoterCustomThankYouScreen(String message, String label, String url) {
+    WootricsdkFlutterPlatform.instance.setPromoterCustomThankYouScreen(message, label, url);
+  }
 }

--- a/lib/wootricsdk_flutter_method_channel.dart
+++ b/lib/wootricsdk_flutter_method_channel.dart
@@ -207,4 +207,15 @@ class MethodChannelWootricsdkFlutter extends WootricsdkFlutterPlatform {
     methodChannel
         .invokeMethod('showWootricSurveyWithEvent', {'eventName': eventName});
   }
+
+  @override
+  setPromoterCustomThankYouScreen(String message, String label, String url) {
+    methodChannel.invokeMethod('setPromoterThankYouMessage', {
+      'promoterThankYouMessage': message
+    });
+    methodChannel.invokeMethod('setPromoterThankYouLinkWithText', {
+      'promoterThankYouLinkText': label,
+      'promoterThankYouLinkURL': url
+    });
+  }
 }

--- a/lib/wootricsdk_flutter_method_channel.dart
+++ b/lib/wootricsdk_flutter_method_channel.dart
@@ -210,12 +210,17 @@ class MethodChannelWootricsdkFlutter extends WootricsdkFlutterPlatform {
 
   @override
   setPromoterCustomThankYouScreen(String message, String label, String url) {
-    methodChannel.invokeMethod('setPromoterThankYouMessage', {
-      'promoterThankYouMessage': message
-    });
-    methodChannel.invokeMethod('setPromoterThankYouLinkWithText', {
-      'promoterThankYouLinkText': label,
-      'promoterThankYouLinkURL': url
+    methodChannel.invokeMethod(
+        'setPromoterThankYouMessage', {'promoterThankYouMessage': message});
+    methodChannel.invokeMethod('setPromoterThankYouLinkWithText',
+        {'promoterThankYouLinkText': label, 'promoterThankYouLinkURL': url});
+  }
+
+  @override
+  setSurveyColors(String primary, [String? secondary]) {
+    methodChannel.invokeMethod('setSurveyColors', {
+      'primary': primary,
+      'secondary': secondary ?? primary,
     });
   }
 }

--- a/lib/wootricsdk_flutter_method_channel.dart
+++ b/lib/wootricsdk_flutter_method_channel.dart
@@ -208,6 +208,7 @@ class MethodChannelWootricsdkFlutter extends WootricsdkFlutterPlatform {
         .invokeMethod('showWootricSurveyWithEvent', {'eventName': eventName});
   }
 
+  ///CUSTOM
   @override
   setPromoterCustomThankYouScreen(String message, String label, String url) {
     methodChannel.invokeMethod(
@@ -216,6 +217,7 @@ class MethodChannelWootricsdkFlutter extends WootricsdkFlutterPlatform {
         {'promoterThankYouLinkText': label, 'promoterThankYouLinkURL': url});
   }
 
+  ///CUSTOM
   @override
   setSurveyColors(String primary, [String? secondary]) {
     methodChannel.invokeMethod('setSurveyColors', {

--- a/lib/wootricsdk_flutter_platform_interface.dart
+++ b/lib/wootricsdk_flutter_platform_interface.dart
@@ -115,11 +115,13 @@ abstract class WootricsdkFlutterPlatform extends PlatformInterface {
   /// Display Wootric survey driven by configured settings and event name.
   showSurveyWithEvent(String eventName) {}
 
+  ///CUSTOM
   /// For promoters (score 9-10)
   /// Display a custom thank you message (setPromoterThankYouMessage)
   /// Display a custom thank you button and link redirect (setPromoterThankYouLinkWithText)
   setPromoterCustomThankYouScreen(String message, String label, String url) {}
 
+  ///CUSTOM
   ///Override survey theme with custom colors for primary and secondary colors.
   ///To set a custom color pass appropriate [primary] and [secondary] in hex format.
   setSurveyColors(String primary, [String? secondary]) {}

--- a/lib/wootricsdk_flutter_platform_interface.dart
+++ b/lib/wootricsdk_flutter_platform_interface.dart
@@ -119,4 +119,8 @@ abstract class WootricsdkFlutterPlatform extends PlatformInterface {
   /// Display a custom thank you message (setPromoterThankYouMessage)
   /// Display a custom thank you button and link redirect (setPromoterThankYouLinkWithText)
   setPromoterCustomThankYouScreen(String message, String label, String url) {}
+
+  ///Override survey theme with custom colors for primary and secondary colors.
+  ///To set a custom color pass appropriate [primary] and [secondary] in hex format.
+  setSurveyColors(String primary, [String? secondary]) {}
 }

--- a/lib/wootricsdk_flutter_platform_interface.dart
+++ b/lib/wootricsdk_flutter_platform_interface.dart
@@ -114,4 +114,9 @@ abstract class WootricsdkFlutterPlatform extends PlatformInterface {
 
   /// Display Wootric survey driven by configured settings and event name.
   showSurveyWithEvent(String eventName) {}
+
+  /// For promoters (score 9-10)
+  /// Display a custom thank you message (setPromoterThankYouMessage)
+  /// Display a custom thank you button and link redirect (setPromoterThankYouLinkWithText)
+  setPromoterCustomThankYouScreen(String message, String label, String url) {}
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: wootricsdk_flutter
 description: This is an official Wootric SDK Wrapper for Flutter. You can visit wootric website for more details. Here is the official documentation for wootric - http://docs.wootric.com/
-version: 0.0.10
+version: 0.0.11
 homepage: https://inmoment.com/wootric/
 repository: https://github.com/Wootric/WootricSDK-flutter/
 issue_tracker: https://github.com/Wootric/WootricSDK-flutter/issues

--- a/test/wootricsdk_flutter_test.dart
+++ b/test/wootricsdk_flutter_test.dart
@@ -79,6 +79,12 @@ class MockWootricsdkFlutterPlatform
   @override
   showDisclaimer(String disclaimerText, String disclaimerLinkURL,
       String disclaimerLinkText) {}
+
+  @override
+  setPromoterCustomThankYouScreen(String message, String label, String url) {}
+
+  @override
+  setSurveyColors(String primary, [String? secondary]) {}
 }
 
 void main() {

--- a/test/wootricsdk_flutter_test.dart
+++ b/test/wootricsdk_flutter_test.dart
@@ -4,132 +4,86 @@ import 'package:wootricsdk_flutter/wootricsdk_flutter_platform_interface.dart';
 import 'package:wootricsdk_flutter/wootricsdk_flutter_method_channel.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
-class MockWootricsdkFlutterPlatform 
+class MockWootricsdkFlutterPlatform
     with MockPlatformInterfaceMixin
     implements WootricsdkFlutterPlatform {
-
   @override
   Future<String?> getPlatformVersion() => Future.value('42');
 
   @override
-  configure({required String clientId, required String accountToken}) {
-
-  }
+  configure({required String clientId, required String accountToken}) {}
 
   @override
-  setEndUserEmail(String endUserEmail) {
-  }
+  setEndUserEmail(String endUserEmail) {}
 
   @override
-  setEndUserExternalId(String endUserExternalId) {
-  }
+  setEndUserExternalId(String endUserExternalId) {}
 
   @override
-  forceSurvey(bool forceSurvey) {
-
-  }
+  forceSurvey(bool forceSurvey) {}
 
   @override
-  passScoreAndTextToURL(bool passScoreAndTextToURL) {
-
-  }
+  passScoreAndTextToURL(bool passScoreAndTextToURL) {}
 
   @override
-  setEndUserCreatedAt(int timestamp) {
-
-  }
+  setEndUserCreatedAt(int timestamp) {}
 
   @override
-  setEndUserPropteries(Map<String, String> endUserProperties) {
-
-  }
+  setFirstSurveyAfter(int numberOfDays) {}
 
   @override
-  setFirstSurveyAfter(int numberOfDays) {
-
-  }
+  setLanguageCode(String languageCode) {}
 
   @override
-  setLanguageCode(String languageCode) {
-
-  }
+  setLogLevelError() {}
 
   @override
-  setLogLevelError() {
-
-  }
+  setLogLevelNone() {}
 
   @override
-  setLogLevelNone() {
-
-  }
+  setLogLevelVerbose() {}
 
   @override
-  setLogLevelVerbose() {
-
-  }
+  setSurveyedDefault(bool surveyedDefault) {}
 
   @override
-  setSurveyedDefault(bool surveyedDefault) {
-
-  }
+  showOptOut(bool showOptOut) {}
 
   @override
-  showOptOut(bool showOptOut) {
-
-  }
+  showSurvey() {}
 
   @override
-  showSurvey() {
-
-  }
+  skipFeedbackScreenForPromoter(bool skipFeedbackScreenForPromoter) {}
 
   @override
-  skipFeedbackScreenForPromoter(bool skipFeedbackScreenForPromoter) {
-
-  }
+  surveyImmediately(bool surveyImmediately) {}
 
   @override
-  surveyImmediately(bool surveyImmediately) {
-
-  }
+  setSendButtonBackgroundColor(String color) {}
 
   @override
-  setSendButtonBackgroundColor(String color) {
-
-  }
+  setSliderColor(String color) {}
 
   @override
-  setSliderColor(String color) {
-
-  }
+  setSocialSharingColor(String color) {}
 
   @override
-  setSocialSharingColor(String color) {
-
-  }
+  setThankYouButtonBackgroundColor(String color) {}
 
   @override
-  setThankYouButtonBackgroundColor(String color) {
-
-  }
+  showSurveyWithEvent(String eventName) {}
 
   @override
-  showSurveyWithEvent(String eventName) {
+  setEndUserProperties(Map<String, String> endUserProperties) {}
 
-  }
-  
   @override
-  setEndUserProperties(Map<String, String> endUserProperties) {
-  }
-  
-  @override
-  showDisclaimer(String disclaimerText, String disclaimerLinkURL, String disclaimerLinkText) {
-  }
+  showDisclaimer(String disclaimerText, String disclaimerLinkURL,
+      String disclaimerLinkText) {}
 }
 
 void main() {
-  final WootricsdkFlutterPlatform initialPlatform = WootricsdkFlutterPlatform.instance;
+  final WootricsdkFlutterPlatform initialPlatform =
+      WootricsdkFlutterPlatform.instance;
 
   test('$MethodChannelWootricsdkFlutter is the default instance', () {
     expect(initialPlatform, isInstanceOf<MethodChannelWootricsdkFlutter>());
@@ -137,9 +91,10 @@ void main() {
 
   test('getPlatformVersion', () async {
     WootricsdkFlutter wootricsdkFlutterPlugin = WootricsdkFlutter();
-    MockWootricsdkFlutterPlatform fakePlatform = MockWootricsdkFlutterPlatform();
+    MockWootricsdkFlutterPlatform fakePlatform =
+        MockWootricsdkFlutterPlatform();
     WootricsdkFlutterPlatform.instance = fakePlatform;
-  
+
     expect(await wootricsdkFlutterPlugin.getPlatformVersion(), '42');
   });
 }


### PR DESCRIPTION
Adiciona métodos customizados que não existem na lib para Flutter: (`lib/wootricsdk_flutter.dart`)
- **setPromoterCustomThankYouScreen**: Personaliza a tela final de agradecimento para votos com notas 9 ou 10;
- **setSurveyTheme**: Personaliza o tema da pesquisa, o tema é configurado no painel do Wootric mas contém erros, então o método foi criado para contornar esses erros;

### setPromoterCustomThankYouScreen()
- **message**: Mensagem personalizada, no iOS ela é o título, no Android é a mensagem abaixo do título, por esse motivo, a mensagem também é configurada no painel do Wootric, porém como configurar apenas lá faz com que não seja possível personalizar o link de redirecionamento por plataforma essa duplicidade é necessária;
- **label**: É o texto do botão que vai fazer o redirecionamento;
- **url**: Url que o usuário vai ser redirecionado quando clicar;

### setSurveyTheme()
- **primary**: Hexa da cor principal da pesquisa;
- **secondary**: Hexa da cor secundária, caso não seja passada, será usada a cor primary;

Obs: As cores devem ser passadas no formato #RRGGBB